### PR TITLE
Fix: get genre list without creating GenreFeatureData object

### DIFF
--- a/predict_example.py
+++ b/predict_example.py
@@ -46,10 +46,10 @@ def extract_audio_features(file):
 def get_genre(model, music_path):
     "Predict genre of music using a trained model"
     prediction = model.predict(extract_audio_features(music_path))
-    print(prediction,np.argmax(prediction),GenreFeatureData().genre_list, sep="\n")
-    plt.bar(GenreFeatureData().genre_list, list(map(lambda x:x*100,prediction[0])))
+    print(prediction, np.argmax(prediction), GenreFeatureData.genre_list, sep="\n")
+    plt.bar(GenreFeatureData.genre_list, list(map(lambda x:x*100,prediction[0])))
     plt.show()
-    predict_genre = GenreFeatureData().genre_list[np.argmax(prediction)]
+    predict_genre = GenreFeatureData.genre_list[np.argmax(prediction)]
     return predict_genre
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-keras
-librosa
-matplotlib
-numpy
-pytorch-lightning
-tensorflow
-torch
-torchvision
+keras==2.11.0
+librosa==0.9.2
+matplotlib==3.6.2
+numpy==1.23.5
+pytorch-lightning==1.8.3.post1
+tensorflow==2.11.0
+torch==1.13.0
+torchvision==0.14.0


### PR DESCRIPTION
`genre_list` is a class variable so, we don't need to create a `GenreFeatureData` object to access it.

Also, since `GenreFeatureData`'s constructor accesses `gtzan` directory (which this repository doesn't have for now), executing `predict_example.py` leads to an error.